### PR TITLE
Typo en nombre de variable occs_data para la función occs_filter_by_mask.R 

### DIFF
--- a/R/occs_filter_by_mask.R
+++ b/R/occs_filter_by_mask.R
@@ -13,7 +13,7 @@ occs_filter_by_mask <- function(this.species,mask){
   sp.temp.data.mask <- list(sp_coords = this.species$occs_data[in_mask_index,
                                                                this.species$lon_lat_vars],
                             sp_occs_year = this.species$sp_occs_year[in_mask_index],
-                            oocs_data = this.species$occs_data[in_mask_index,],
+                            occs_data = this.species$occs_data[in_mask_index,],
                             lon_lat_vars = this.species$lon_lat_vars ,
                             layers_path_by_year = this.species$layers_path_by_year)
   class(sp.temp.data.mask) <- c("list", "sp.temporal.modeling")


### PR DESCRIPTION
Buen día Luis espero estés bien.

Realizando más pruebas del pipeline que estamos construyendo Mariana y yo para el HSI, decidimos utilizar la función [occs_filter_by_mask.R](https://github.com/luismurao/hsi/blob/master/R/occs_filter_by_mask.R). Sin embargo al utilizar el objeto que regresa tal función quisimos acceder a la variable `occs_data` pero como puedes observar en la línea [occs_filter_by_mask.R#L16](https://github.com/luismurao/hsi/blob/master/R/occs_filter_by_mask.R#L16) el nombre de la variable ya no es `occs_data` sino `oocs_data`. Por lo que viendo que deben ser de la misma clase `sp.temporal.modeling` el objeto que entra y el objeto que regresa supusimos que fue un typo. En este PR se realiza el cambio de nombre de tal variable, es un cambio pequeño.

Te envío el PR para su revisión.

Saludos,

Erick